### PR TITLE
Optionally derive reflect and serialize on `Palette`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ pub struct BspParseContext {
 /// An Id Tech 1 palette to use for embedded images.
 #[repr(C)] // Because we transmute data with QUAKE_PALETTE, don't want Rust to pull any shenanigans
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Palette {
 	pub colors: [[u8; 3]; 256],
 }


### PR DESCRIPTION
Useful for including as a per-load override in an asset loader, as `bevy_asset::AssetLoader::Settings` requires `Serialize + Deserialize`.