### PR TITLE
Remove dependencies on `qbsp` types from lightmap packer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /target
 /.vscode
 /.idea

--- a/src/mesh/lightmap/mod.rs
+++ b/src/mesh/lightmap/mod.rs
@@ -121,24 +121,25 @@ impl BspData {
 
 			let decoupled_lightmap = self.bspx.decoupled_lm.as_ref().map(|lm_infos| lm_infos[face_idx]);
 
+			let lm_extents;
 			let lm_info = match &decoupled_lightmap {
 				Some(lm_info) => {
 					let uvs: FaceUvs = face.vertices(self).map(|pos| lm_info.projection.project(pos)).collect();
-					let extents = FaceExtents::new_decoupled(uvs.iter().copied(), lm_info);
+					lm_extents = FaceExtents::new_decoupled(uvs.iter().copied(), lm_info);
 
 					LightmapInfo {
 						uvs,
-						extents,
+						lightmap_size: lm_extents.lightmap_size(),
 						lightmap_offset: lm_info.offset.pixels,
 					}
 				}
 				None => {
 					let uvs: FaceUvs = face.vertices(self).map(|pos| tex_info.projection.project(pos)).collect();
-					let extents = FaceExtents::new(uvs.iter().copied());
+					lm_extents = FaceExtents::new(uvs.iter().copied());
 
 					LightmapInfo {
 						uvs,
-						extents,
+						lightmap_size: lm_extents.lightmap_size(),
 						lightmap_offset: face.lightmap_offset.pixels,
 					}
 				}
@@ -152,7 +153,7 @@ impl BspData {
 				lighting_buffer,
 			};
 
-			if lm_info.lightmap_offset.is_negative() || lm_info.extents.lightmap_size() == UVec2::ZERO {
+			if lm_info.lightmap_offset.is_negative() || lm_info.lightmap_size == UVec2::ZERO {
 				lightmap_uvs.insert(
 					face_idx as u32,
 					if tex_info.flags.texture_flags.unwrap_or_default() == BspTexFlags::Normal {
@@ -170,8 +171,7 @@ impl BspData {
 
 			lightmap_uvs.insert(
 				face_idx as u32,
-				lm_info
-					.extents
+				lm_extents
 					.compute_lightmap_uvs(lm_info.uvs, (frame.min + settings.extrusion).as_vec2())
 					.collect(),
 			);
@@ -207,7 +207,7 @@ impl BspData {
 pub struct LightmapInfo {
 	/// The vertices of the face projected onto it's texture or decoupled lightmap.
 	pub uvs: FaceUvs,
-	pub extents: FaceExtents,
+	pub lightmap_size: UVec2,
 	/// The offset into the lightmap lump in bytes to read the lightmap data or -1. Will need to be multiplied by 3 for colored lighting.
 	pub lightmap_offset: i32,
 }
@@ -215,9 +215,7 @@ impl LightmapInfo {
 	/// Computes the index into [`BspLighting`](crate::data::lighting::BspLighting) for the specific face specified. Assumes [`lightmap_offset`](Self::lightmap_offset) is positive.
 	#[inline]
 	pub fn compute_lighting_index(&self, light_style_idx: usize, x: u32, y: u32) -> usize {
-		self.lightmap_offset as usize
-			+ (self.extents.lightmap_pixels() as usize * light_style_idx)
-			+ (y * self.extents.lightmap_size().x + x) as usize
+		self.lightmap_offset as usize + (self.lightmap_size.element_product() as usize * light_style_idx) + (y * self.lightmap_size.x + x) as usize
 	}
 }
 

--- a/src/mesh/lightmap/mod.rs
+++ b/src/mesh/lightmap/mod.rs
@@ -133,8 +133,6 @@ impl BspData {
 			let view = LightmapPackerFaceView {
 				lm_info: &lm_info,
 
-				bsp: self,
-
 				face_idx,
 				face,
 				tex_info,

--- a/src/mesh/lightmap/mod.rs
+++ b/src/mesh/lightmap/mod.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use glam::{UVec2, Vec2, uvec2};
+use image::{DynamicImage, GenericImageView, ImageBuffer, Luma, Pixel, Rgb};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smallvec::{SmallVec, smallvec};
@@ -10,11 +11,11 @@ use thiserror::Error;
 
 mod packer;
 
-pub use packer::{DefaultLightmapPacker, LightmapPacker, LightmapPackerFaceView, PerSlotLightmapPacker, PerStyleLightmapPacker};
+pub use packer::{DefaultLightmapPacker, LightmapPacker, LightmapPackerFaceView, PerSlotLightmapPackerRgb, PerStyleLightmapPackerRgb};
 
 use crate::{
 	BspData,
-	data::{lighting::LightmapStyle, texture::BspTexFlags},
+	data::{BspLighting, lighting::LightmapStyle, texture::BspTexFlags},
 	mesh::FaceExtents,
 };
 
@@ -69,17 +70,22 @@ impl ReservedLightmapPixel {
 		Self { position: None, color }
 	}
 
-	pub fn get_uvs<P: LightmapPacker>(
+	pub fn get_uvs<P, Px>(
 		&mut self,
 		lightmap_packer: &mut P,
 		num_edges: usize,
-		view: LightmapPackerFaceView,
-	) -> Result<FaceUvs, ComputeLightmapAtlasError> {
+		view: LightmapPackerFaceView<Px::Subpixel>,
+	) -> Result<FaceUvs, ComputeLightmapAtlasError>
+	where
+		P: LightmapPacker,
+		Px: Pixel,
+		DynamicImage: From<ImageBuffer<Px, Vec<Px::Subpixel>>>,
+	{
 		let position = match self.position {
 			Some(v) => v,
 			None => {
 				// TODO: Is this handled by `texture_packer`?
-				let rect = lightmap_packer.pack(
+				let rect = lightmap_packer.pack::<Px>(
 					view,
 					P::create_single_color_input(UVec2::ONE + lightmap_packer.settings().extrusion * 2, self.color),
 				)?;
@@ -93,10 +99,16 @@ impl ReservedLightmapPixel {
 }
 
 impl BspData {
-	/// Packs every face's lightmap together onto a single atlas for GPU rendering.
-	pub fn compute_lightmap_atlas<P: LightmapPacker>(&self, mut packer: P) -> Result<LightmapAtlasOutput<P>, ComputeLightmapAtlasError> {
-		let Some(lighting) = &self.lighting else { return Err(ComputeLightmapAtlasError::NoLightmaps) };
-
+	fn compute_lightmap_atlas_with_pixel<P, Px>(
+		&self,
+		mut packer: P,
+		lighting_buffer: &[Px::Subpixel],
+	) -> Result<LightmapAtlasOutput<P>, ComputeLightmapAtlasError>
+	where
+		P: LightmapPacker,
+		Px: Pixel,
+		DynamicImage: From<ImageBuffer<Px, Vec<Px::Subpixel>>>,
+	{
 		let settings = packer.settings();
 
 		let mut lightmap_uvs: HashMap<u32, FaceUvs> = HashMap::new();
@@ -137,24 +149,24 @@ impl BspData {
 
 				face_idx,
 				lightmap_styles: face.lightmap_styles,
-				lighting,
+				lighting_buffer,
 			};
 
 			if lm_info.lightmap_offset.is_negative() || lm_info.extents.lightmap_size() == UVec2::ZERO {
 				lightmap_uvs.insert(
 					face_idx as u32,
 					if tex_info.flags.texture_flags.unwrap_or_default() == BspTexFlags::Normal {
-						empty_reserved_pixel.get_uvs(&mut packer, face.num_edges.0 as usize, view)?
+						empty_reserved_pixel.get_uvs::<P, Px>(&mut packer, face.num_edges.0 as usize, view)?
 					} else {
-						special_reserved_pixel.get_uvs(&mut packer, face.num_edges.0 as usize, view)?
+						special_reserved_pixel.get_uvs::<P, Px>(&mut packer, face.num_edges.0 as usize, view)?
 					},
 				);
 				continue;
 			}
 
-			let input = packer.read_from_face(view);
+			let input = packer.read_from_face::<Px>(view);
 
-			let frame = packer.pack(view, input)?;
+			let frame = packer.pack::<Px>(view, input)?;
 
 			lightmap_uvs.insert(
 				face_idx as u32,
@@ -178,6 +190,15 @@ impl BspData {
 			uvs: lightmap_uvs,
 			data: atlas,
 		})
+	}
+
+	/// Packs every face's lightmap together onto a single atlas for GPU rendering.
+	pub fn compute_lightmap_atlas<P: LightmapPacker>(&self, packer: P) -> Result<LightmapAtlasOutput<P>, ComputeLightmapAtlasError> {
+		match &self.lighting {
+			Some(BspLighting::Grayscale(data)) => self.compute_lightmap_atlas_with_pixel::<P, Luma<u8>>(packer, data),
+			Some(BspLighting::Colored(data)) => self.compute_lightmap_atlas_with_pixel::<P, Rgb<u8>>(packer, data.as_flattened()),
+			None => todo!(),
+		}
 	}
 }
 
@@ -205,9 +226,9 @@ pub trait LightmapAtlas {
 	fn size(&self) -> UVec2;
 }
 
-pub struct PerSlotLightmapData {
-	pub slots: [image::RgbImage; 4],
-	pub styles: image::RgbaImage,
+pub struct PerSlotLightmapData<Opaque = image::RgbImage, Translucent = image::RgbaImage> {
+	pub slots: [Opaque; 4],
+	pub styles: Translucent,
 }
 impl LightmapAtlas for PerSlotLightmapData {
 	fn size(&self) -> UVec2 {
@@ -219,11 +240,15 @@ impl LightmapAtlas for PerSlotLightmapData {
 ///
 /// This is just a wrapper for a HashMap that ensures that all containing images are the same size.
 #[derive(Debug, Clone)]
-pub struct PerStyleLightmapData {
+pub struct PerStyleLightmapData<Image = image::RgbImage> {
 	size: UVec2,
-	inner: HashMap<LightmapStyle, image::RgbImage>,
+	inner: HashMap<LightmapStyle, Image>,
 }
-impl PerStyleLightmapData {
+
+impl<Image> PerStyleLightmapData<Image>
+where
+	Image: GenericImageView,
+{
 	#[inline]
 	pub fn new(size: impl Into<UVec2>) -> Self {
 		Self {
@@ -233,20 +258,17 @@ impl PerStyleLightmapData {
 	}
 
 	#[inline]
-	pub fn inner(&self) -> &HashMap<LightmapStyle, image::RgbImage> {
+	pub fn inner(&self) -> &HashMap<LightmapStyle, Image> {
 		&self.inner
 	}
 
 	#[inline]
-	pub fn into_inner(self) -> HashMap<LightmapStyle, image::RgbImage> {
+	pub fn into_inner(self) -> HashMap<LightmapStyle, Image> {
 		self.inner
 	}
 
 	/// Modifies the internal map, checking to ensure all images are the same size after.
-	pub fn modify_inner<O, F: FnOnce(&mut HashMap<LightmapStyle, image::RgbImage>) -> O>(
-		&mut self,
-		modifier: F,
-	) -> Result<O, LightmapsInvalidSizeError> {
+	pub fn modify_inner<O, F: FnOnce(&mut HashMap<LightmapStyle, Image>) -> O>(&mut self, modifier: F) -> Result<O, LightmapsInvalidSizeError> {
 		let out = modifier(&mut self.inner);
 
 		for (style, image) in &self.inner {
@@ -264,7 +286,7 @@ impl PerStyleLightmapData {
 	}
 
 	/// Inserts a new image into the collection. Returns `Err` if the atlas' size doesn't match the collection's expected size.
-	pub fn insert(&mut self, style: LightmapStyle, image: image::RgbImage) -> Result<Option<image::RgbImage>, LightmapsInvalidSizeError> {
+	pub fn insert(&mut self, style: LightmapStyle, image: Image) -> Result<Option<Image>, LightmapsInvalidSizeError> {
 		let image_size = uvec2(image.width(), image.height());
 		if self.size != image_size {
 			return Err(LightmapsInvalidSizeError {
@@ -277,7 +299,8 @@ impl PerStyleLightmapData {
 		Ok(self.inner.insert(style, image))
 	}
 }
-impl LightmapAtlas for PerStyleLightmapData {
+
+impl<Image> LightmapAtlas for PerStyleLightmapData<Image> {
 	fn size(&self) -> UVec2 {
 		self.size
 	}

--- a/src/mesh/lightmap/mod.rs
+++ b/src/mesh/lightmap/mod.rs
@@ -122,23 +122,22 @@ impl BspData {
 			let decoupled_lightmap = self.bspx.decoupled_lm.as_ref().map(|lm_infos| lm_infos[face_idx]);
 
 			let lm_extents;
+			let lm_uvs: FaceUvs;
 			let lm_info = match &decoupled_lightmap {
 				Some(lm_info) => {
-					let uvs: FaceUvs = face.vertices(self).map(|pos| lm_info.projection.project(pos)).collect();
-					lm_extents = FaceExtents::new_decoupled(uvs.iter().copied(), lm_info);
+					lm_uvs = face.vertices(self).map(|pos| lm_info.projection.project(pos)).collect();
+					lm_extents = FaceExtents::new_decoupled(lm_uvs.iter().copied(), lm_info);
 
 					LightmapInfo {
-						uvs,
 						lightmap_size: lm_extents.lightmap_size(),
 						lightmap_offset: lm_info.offset.pixels,
 					}
 				}
 				None => {
-					let uvs: FaceUvs = face.vertices(self).map(|pos| tex_info.projection.project(pos)).collect();
-					lm_extents = FaceExtents::new(uvs.iter().copied());
+					lm_uvs = face.vertices(self).map(|pos| tex_info.projection.project(pos)).collect();
+					lm_extents = FaceExtents::new(lm_uvs.iter().copied());
 
 					LightmapInfo {
-						uvs,
 						lightmap_size: lm_extents.lightmap_size(),
 						lightmap_offset: face.lightmap_offset.pixels,
 					}
@@ -172,7 +171,7 @@ impl BspData {
 			lightmap_uvs.insert(
 				face_idx as u32,
 				lm_extents
-					.compute_lightmap_uvs(lm_info.uvs, (frame.min + settings.extrusion).as_vec2())
+					.compute_lightmap_uvs(lm_uvs, (frame.min + settings.extrusion).as_vec2())
 					.collect(),
 			);
 		}
@@ -205,8 +204,6 @@ impl BspData {
 /// Computed information about the specifics of how a lightmap applies to a face.
 #[derive(Debug, Clone)]
 pub struct LightmapInfo {
-	/// The vertices of the face projected onto it's texture or decoupled lightmap.
-	pub uvs: FaceUvs,
 	pub lightmap_size: UVec2,
 	/// The offset into the lightmap lump in bytes to read the lightmap data or -1. Will need to be multiplied by 3 for colored lighting.
 	pub lightmap_offset: i32,

--- a/src/mesh/lightmap/mod.rs
+++ b/src/mesh/lightmap/mod.rs
@@ -59,10 +59,11 @@ pub enum ComputeLightmapAtlasError {
 	NoLightmaps,
 }
 
-struct ReservedLightmapPixel {
-	position: Option<UVec2>,
-	color: [u8; 3],
+pub struct ReservedLightmapPixel {
+	pub position: Option<UVec2>,
+	pub color: [u8; 3],
 }
+
 impl ReservedLightmapPixel {
 	pub fn new(color: [u8; 3]) -> Self {
 		Self { position: None, color }
@@ -71,6 +72,7 @@ impl ReservedLightmapPixel {
 	pub fn get_uvs<P: LightmapPacker>(
 		&mut self,
 		lightmap_packer: &mut P,
+		num_edges: usize,
 		view: LightmapPackerFaceView,
 	) -> Result<FaceUvs, ComputeLightmapAtlasError> {
 		let position = match self.position {
@@ -86,7 +88,7 @@ impl ReservedLightmapPixel {
 			}
 		};
 
-		Ok(smallvec![position.as_vec2() + Vec2::splat(0.5); view.face.num_edges.0 as usize])
+		Ok(smallvec![position.as_vec2() + Vec2::splat(0.5); num_edges])
 	}
 }
 
@@ -134,8 +136,7 @@ impl BspData {
 				lm_info: &lm_info,
 
 				face_idx,
-				face,
-				tex_info,
+				lightmap_styles: face.lightmap_styles,
 				lighting,
 			};
 
@@ -143,9 +144,9 @@ impl BspData {
 				lightmap_uvs.insert(
 					face_idx as u32,
 					if tex_info.flags.texture_flags.unwrap_or_default() == BspTexFlags::Normal {
-						empty_reserved_pixel.get_uvs(&mut packer, view)?
+						empty_reserved_pixel.get_uvs(&mut packer, face.num_edges.0 as usize, view)?
 					} else {
-						special_reserved_pixel.get_uvs(&mut packer, view)?
+						special_reserved_pixel.get_uvs(&mut packer, face.num_edges.0 as usize, view)?
 					},
 				);
 				continue;

--- a/src/mesh/lightmap/packer.rs
+++ b/src/mesh/lightmap/packer.rs
@@ -181,23 +181,22 @@ where
 		DynamicImage: From<ImageBuffer<P, Vec<P::Subpixel>>>,
 	{
 		if view.lightmap_styles[0] == LightmapStyle::NONE {
-			Self::create_single_color_input(view.lm_info.extents.lightmap_size(), [0; 3])
+			Self::create_single_color_input(view.lm_info.lightmap_size, [0; 3])
 		} else {
-			let mut lightmaps = PerStyleLightmapData::<Image>::new(view.lm_info.extents.lightmap_size());
+			let mut lightmaps = PerStyleLightmapData::<Image>::new(view.lm_info.lightmap_size);
 			for (i, style) in view.lightmap_styles.into_iter().enumerate() {
 				if style == LightmapStyle::NONE {
 					break;
 				}
 
-				let lm_size = view.lm_info.extents.lightmap_size();
+				let lm_size = view.lm_info.lightmap_size;
 
-				let start = view.lm_info.compute_lighting_index(i, 0, 0);
-				let end = view
-					.lm_info
-					.compute_lighting_index(i, lm_size.x.saturating_sub(1), lm_size.y.saturating_sub(1));
+				let start = view.lm_info.compute_lighting_index(i, 0, 0) * P::CHANNEL_COUNT as usize;
+				let end = start + view.lm_info.lightmap_size.element_product() as usize * P::CHANNEL_COUNT as usize;
 
-				let lightmap_data = image::ImageBuffer::<P, _>::from_raw(lm_size.x, lm_size.y, view.lighting_buffer[start..=end].to_vec())
-					.expect("Failed to create lightmap image");
+				let Some(buffer) = view.lighting_buffer.get(start..end) else { return Self::create_single_color_input(lm_size, [0; 3]) };
+				let lightmap_data =
+					image::ImageBuffer::<P, _>::from_raw(lm_size.x, lm_size.y, buffer.to_vec()).expect("Failed to create lightmap image");
 				let rgb_image = DynamicImage::from(lightmap_data).into();
 
 				lightmaps.insert(style, rgb_image).unwrap();
@@ -287,7 +286,7 @@ impl LightmapPacker for PerSlotLightmapPackerRgb {
 	{
 		let mut i = 0;
 		view.lightmap_styles.map(|style| {
-			let UVec2 { x: width, y: height } = view.lm_info.extents.lightmap_size();
+			let UVec2 { x: width, y: height } = view.lm_info.lightmap_size;
 
 			let image = if style == LightmapStyle::NONE {
 				image::RgbImage::from_pixel(width, height, self.settings.default_color.into())

--- a/src/mesh/lightmap/packer.rs
+++ b/src/mesh/lightmap/packer.rs
@@ -5,12 +5,13 @@
 use std::collections::HashMap;
 
 use glam::{UVec2, uvec2};
+use image::{DynamicImage, GenericImage, ImageBuffer, Pixel};
 use texture_packer::{TexturePacker, TexturePackerConfig, texture::Texture};
 
 use super::ComputeLightmapSettings;
 
 use crate::{
-	data::lighting::{BspLighting, LightmapStyle},
+	data::lighting::LightmapStyle,
 	mesh::lightmap::{ComputeLightmapAtlasError, LightmapAtlas, LightmapInfo, PerSlotLightmapData, PerStyleLightmapData},
 	util::Rect,
 };
@@ -21,23 +22,28 @@ pub trait LightmapPacker {
 	type Output: LightmapAtlas;
 
 	fn create_single_color_input(size: impl Into<UVec2>, color: [u8; 3]) -> Self::Input;
-	fn read_from_face(&self, view: LightmapPackerFaceView) -> Self::Input;
+	fn read_from_face<P>(&self, view: LightmapPackerFaceView<P::Subpixel>) -> Self::Input
+	where
+		P: Pixel,
+		DynamicImage: From<ImageBuffer<P, Vec<P::Subpixel>>>;
 
 	fn settings(&self) -> ComputeLightmapSettings;
 
-	fn pack(&mut self, view: LightmapPackerFaceView, images: Self::Input) -> Result<Rect<UVec2>, ComputeLightmapAtlasError>;
+	fn pack<P>(&mut self, view: LightmapPackerFaceView<P::Subpixel>, images: Self::Input) -> Result<Rect<UVec2>, ComputeLightmapAtlasError>
+	where
+		P: Pixel,
+		DynamicImage: From<ImageBuffer<P, Vec<P::Subpixel>>>;
 	fn export(&self) -> Self::Output;
 }
 
 /// Information provided to read a lightmap from a face.
 #[derive(Clone, Copy)]
-pub struct LightmapPackerFaceView<'a> {
+pub struct LightmapPackerFaceView<'a, P> {
 	pub lm_info: &'a LightmapInfo,
 
 	pub face_idx: usize,
 	pub lightmap_styles: [LightmapStyle; 4],
-	/// Shortcut for `bsp.lighting` since it's guaranteed to be [`Some`].
-	pub lighting: &'a BspLighting,
+	pub lighting_buffer: &'a [P],
 }
 
 /// Currently, we use texture_packer to create atlas' and have to do
@@ -100,7 +106,16 @@ impl<LM> DefaultLightmapPacker<LM> {
 		}
 	}
 
-	fn allocate_and_push(&mut self, view: LightmapPackerFaceView, width: u32, height: u32, lm: LM) -> Result<Rect<UVec2>, ComputeLightmapAtlasError> {
+	fn allocate_and_push<P>(
+		&mut self,
+		view: LightmapPackerFaceView<P::Subpixel>,
+		width: u32,
+		height: u32,
+		lm: LM,
+	) -> Result<Rect<UVec2>, ComputeLightmapAtlasError>
+	where
+		P: Pixel,
+	{
 		self.packer
 			.pack_own(view.face_idx as u32, DummyTexture { width, height })
 			.map_err(|_| ComputeLightmapAtlasError::PackFailure {
@@ -138,39 +153,56 @@ impl<LM> DefaultLightmapPacker<LM> {
 	}
 }
 
-pub type PerStyleLightmapPacker = DefaultLightmapPacker<PerStyleLightmapData>;
-pub type PerSlotLightmapPacker = DefaultLightmapPacker<[(image::RgbImage, LightmapStyle); 4]>;
+pub type PerStyleLightmapPackerRgb = DefaultLightmapPacker<PerStyleLightmapData>;
+pub type PerSlotLightmapPackerRgb = DefaultLightmapPacker<[(image::RgbImage, LightmapStyle); 4]>;
 
-impl LightmapPacker for PerStyleLightmapPacker {
-	type Input = PerStyleLightmapData;
-	type Output = PerStyleLightmapData;
+impl<Image> LightmapPacker for DefaultLightmapPacker<PerStyleLightmapData<Image>>
+where
+	Image: GenericImage,
+	DynamicImage: Into<Image>,
+{
+	type Input = PerStyleLightmapData<Image>;
+	type Output = PerStyleLightmapData<Image>;
 
 	fn create_single_color_input(size: impl Into<UVec2>, color: [u8; 3]) -> Self::Input {
 		let size = size.into();
+
+		let image = DynamicImage::from(image::RgbImage::from_pixel(size.x, size.y, image::Rgb(color))).into();
+
 		PerStyleLightmapData {
 			size,
-			inner: HashMap::from([(LightmapStyle::NORMAL, image::RgbImage::from_pixel(size.x, size.y, image::Rgb(color)))]),
+			inner: HashMap::from([(LightmapStyle::NORMAL, image)]),
 		}
 	}
 
-	fn read_from_face(&self, view: LightmapPackerFaceView) -> Self::Input {
+	fn read_from_face<P>(&self, view: LightmapPackerFaceView<P::Subpixel>) -> Self::Input
+	where
+		P: Pixel,
+		DynamicImage: From<ImageBuffer<P, Vec<P::Subpixel>>>,
+	{
 		if view.lightmap_styles[0] == LightmapStyle::NONE {
 			Self::create_single_color_input(view.lm_info.extents.lightmap_size(), [0; 3])
 		} else {
-			let mut lightmaps = PerStyleLightmapData::new(view.lm_info.extents.lightmap_size());
+			let mut lightmaps = PerStyleLightmapData::<Image>::new(view.lm_info.extents.lightmap_size());
 			for (i, style) in view.lightmap_styles.into_iter().enumerate() {
 				if style == LightmapStyle::NONE {
 					break;
 				}
-				lightmaps
-					.insert(
-						style,
-						image::RgbImage::from_fn(view.lm_info.extents.lightmap_size().x, view.lm_info.extents.lightmap_size().y, |x, y| {
-							image::Rgb(view.lighting.get(view.lm_info.compute_lighting_index(i, x, y)).unwrap_or_default())
-						}),
-					)
-					.unwrap();
+
+				let lm_size = view.lm_info.extents.lightmap_size();
+
+				let start = view.lm_info.compute_lighting_index(i, 0, 0);
+				let end = view
+					.lm_info
+					.compute_lighting_index(i, lm_size.x.saturating_sub(1), lm_size.y.saturating_sub(1));
+
+				let lightmap_data = image::ImageBuffer::<P, _>::from_raw(lm_size.x, lm_size.y, view.lighting_buffer[start..=end].to_vec())
+					.expect("Failed to create lightmap image");
+				let rgb_image = DynamicImage::from(lightmap_data).into();
+
+				lightmaps.insert(style, rgb_image).unwrap();
 			}
+
 			lightmaps
 		}
 	}
@@ -179,14 +211,18 @@ impl LightmapPacker for PerStyleLightmapPacker {
 		self.settings
 	}
 
-	fn pack(&mut self, view: LightmapPackerFaceView, lightmaps: Self::Input) -> Result<Rect<UVec2>, ComputeLightmapAtlasError> {
-		self.allocate_and_push(view, lightmaps.size().x, lightmaps.size().y, lightmaps)
+	fn pack<P>(&mut self, view: LightmapPackerFaceView<P::Subpixel>, lightmaps: Self::Input) -> Result<Rect<UVec2>, ComputeLightmapAtlasError>
+	where
+		P: Pixel,
+		DynamicImage: From<ImageBuffer<P, Vec<P::Subpixel>>>,
+	{
+		self.allocate_and_push::<P>(view, lightmaps.size().x, lightmaps.size().y, lightmaps)
 	}
 
 	fn export(&self) -> Self::Output {
 		let size = self.total_size();
 
-		let mut atlas = PerStyleLightmapData::new(size);
+		let mut atlas = PerStyleLightmapData::<Image>::new(size);
 		let [atlas_width, atlas_height] = atlas.size().to_array();
 
 		for (frame, lightmap_images) in &self.images {
@@ -195,9 +231,14 @@ impl LightmapPacker for PerStyleLightmapPacker {
 			for (light_style, lightmap_image) in lightmap_images.inner() {
 				atlas
 					.modify_inner(|map| {
-						let dst_image = map
-							.entry(*light_style)
-							.or_insert_with(|| image::RgbImage::from_pixel(atlas_width, atlas_height, image::Rgb(self.settings.default_color)));
+						let dst_image = map.entry(*light_style).or_insert_with(|| {
+							DynamicImage::from(image::RgbImage::from_pixel(
+								atlas_width,
+								atlas_height,
+								image::Rgb(self.settings.default_color),
+							))
+							.into()
+						});
 
 						for x in 0..frame_width + self.settings.extrusion * 2 {
 							let global_x = frame.min.x + x;
@@ -214,7 +255,7 @@ impl LightmapPacker for PerStyleLightmapPacker {
 								dst_image.put_pixel(
 									global_x,
 									global_y,
-									*lightmap_image.get_pixel(
+									lightmap_image.get_pixel(
 										x.saturating_sub(self.settings.extrusion).min(frame_width - 1),
 										y.saturating_sub(self.settings.extrusion).min(frame_height - 1),
 									),
@@ -230,7 +271,7 @@ impl LightmapPacker for PerStyleLightmapPacker {
 	}
 }
 
-impl LightmapPacker for PerSlotLightmapPacker {
+impl LightmapPacker for PerSlotLightmapPackerRgb {
 	type Input = [(image::RgbImage, LightmapStyle); 4];
 	type Output = PerSlotLightmapData;
 
@@ -239,18 +280,25 @@ impl LightmapPacker for PerSlotLightmapPacker {
 		[(); 4].map(|_| (image::RgbImage::from_pixel(size.x, size.y, image::Rgb(color)), LightmapStyle::NORMAL))
 	}
 
-	fn read_from_face(&self, view: LightmapPackerFaceView) -> Self::Input {
+	fn read_from_face<P>(&self, view: LightmapPackerFaceView<P::Subpixel>) -> Self::Input
+	where
+		P: Pixel,
+		DynamicImage: From<ImageBuffer<P, Vec<P::Subpixel>>>,
+	{
 		let mut i = 0;
 		view.lightmap_styles.map(|style| {
 			let UVec2 { x: width, y: height } = view.lm_info.extents.lightmap_size();
 
-			let image = image::RgbImage::from_fn(width, height, |x, y| {
-				if style == LightmapStyle::NONE {
-					image::Rgb(self.settings.default_color)
-				} else {
-					image::Rgb(view.lighting.get(view.lm_info.compute_lighting_index(i, x, y)).unwrap_or_default())
-				}
-			});
+			let image = if style == LightmapStyle::NONE {
+				image::RgbImage::from_pixel(width, height, self.settings.default_color.into())
+			} else {
+				let start = view.lm_info.compute_lighting_index(i, 0, 0);
+				let end = view.lm_info.compute_lighting_index(i, width.saturating_sub(1), height.saturating_sub(1));
+
+				let lightmap_data = image::ImageBuffer::<P, _>::from_raw(width, height, view.lighting_buffer[start..=end].to_vec())
+					.expect("Failed to create lightmap image");
+				DynamicImage::from(lightmap_data).into_rgb8()
+			};
 
 			i += 1;
 
@@ -262,14 +310,17 @@ impl LightmapPacker for PerSlotLightmapPacker {
 		self.settings
 	}
 
-	fn pack(&mut self, view: LightmapPackerFaceView, images: Self::Input) -> Result<Rect<UVec2>, ComputeLightmapAtlasError> {
+	fn pack<P>(&mut self, view: LightmapPackerFaceView<P::Subpixel>, images: Self::Input) -> Result<Rect<UVec2>, ComputeLightmapAtlasError>
+	where
+		P: Pixel,
+	{
 		let size = images
 			.iter()
 			.map(|(image, _)| uvec2(image.width(), image.height()))
 			.reduce(UVec2::max)
 			.unwrap();
 
-		self.allocate_and_push(view, size.x, size.y, images)
+		self.allocate_and_push::<P>(view, size.x, size.y, images)
 	}
 
 	fn export(&self) -> Self::Output {

--- a/src/mesh/lightmap/packer.rs
+++ b/src/mesh/lightmap/packer.rs
@@ -10,11 +10,7 @@ use texture_packer::{TexturePacker, TexturePackerConfig, texture::Texture};
 use super::ComputeLightmapSettings;
 
 use crate::{
-	data::{
-		lighting::{BspLighting, LightmapStyle},
-		models::BspFace,
-		texture::BspTexInfo,
-	},
+	data::lighting::{BspLighting, LightmapStyle},
 	mesh::lightmap::{ComputeLightmapAtlasError, LightmapAtlas, LightmapInfo, PerSlotLightmapData, PerStyleLightmapData},
 	util::Rect,
 };
@@ -39,10 +35,7 @@ pub struct LightmapPackerFaceView<'a> {
 	pub lm_info: &'a LightmapInfo,
 
 	pub face_idx: usize,
-	/// Shortcut for `bsp.faces[face_idx]`.
-	pub face: &'a BspFace,
-	/// Shortcut for `bsp.tex_info[bsp.faces[face_idx].texture_info_idx]`.
-	pub tex_info: &'a BspTexInfo,
+	pub lightmap_styles: [LightmapStyle; 4],
 	/// Shortcut for `bsp.lighting` since it's guaranteed to be [`Some`].
 	pub lighting: &'a BspLighting,
 }
@@ -161,11 +154,11 @@ impl LightmapPacker for PerStyleLightmapPacker {
 	}
 
 	fn read_from_face(&self, view: LightmapPackerFaceView) -> Self::Input {
-		if view.face.lightmap_styles[0] == LightmapStyle::NONE {
+		if view.lightmap_styles[0] == LightmapStyle::NONE {
 			Self::create_single_color_input(view.lm_info.extents.lightmap_size(), [0; 3])
 		} else {
 			let mut lightmaps = PerStyleLightmapData::new(view.lm_info.extents.lightmap_size());
-			for (i, style) in view.face.lightmap_styles.into_iter().enumerate() {
+			for (i, style) in view.lightmap_styles.into_iter().enumerate() {
 				if style == LightmapStyle::NONE {
 					break;
 				}
@@ -248,7 +241,7 @@ impl LightmapPacker for PerSlotLightmapPacker {
 
 	fn read_from_face(&self, view: LightmapPackerFaceView) -> Self::Input {
 		let mut i = 0;
-		view.face.lightmap_styles.map(|style| {
+		view.lightmap_styles.map(|style| {
 			let UVec2 { x: width, y: height } = view.lm_info.extents.lightmap_size();
 
 			let image = image::RgbImage::from_fn(width, height, |x, y| {

--- a/src/mesh/lightmap/packer.rs
+++ b/src/mesh/lightmap/packer.rs
@@ -10,7 +10,6 @@ use texture_packer::{TexturePacker, TexturePackerConfig, texture::Texture};
 use super::ComputeLightmapSettings;
 
 use crate::{
-	BspData,
 	data::{
 		lighting::{BspLighting, LightmapStyle},
 		models::BspFace,
@@ -38,8 +37,6 @@ pub trait LightmapPacker {
 #[derive(Clone, Copy)]
 pub struct LightmapPackerFaceView<'a> {
 	pub lm_info: &'a LightmapInfo,
-
-	pub bsp: &'a BspData,
 
 	pub face_idx: usize,
 	/// Shortcut for `bsp.faces[face_idx]`.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,5 +7,5 @@ pub use qbsp_macros::{BspValue, BspVariableValue};
 #[cfg(feature = "meshing")]
 pub use crate::mesh::{
 	ExportedMesh,
-	lightmap::{ComputeLightmapSettings, LightmapUvMap, PerSlotLightmapPacker, PerStyleLightmapPacker},
+	lightmap::{ComputeLightmapSettings, LightmapUvMap, PerSlotLightmapPackerRgb, PerStyleLightmapPackerRgb},
 };

--- a/tools/write-lightmaps/src/main.rs
+++ b/tools/write-lightmaps/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 	fs::create_dir("target/lightmaps/per-slot").unwrap();
 
 	eprintln!("Computing per slot lightmap atlas");
-	let atlas = data.compute_lightmap_atlas(PerSlotLightmapPacker::new(lightmap_settings)).unwrap();
+	let atlas = data.compute_lightmap_atlas(PerSlotLightmapPackerRgb::new(lightmap_settings)).unwrap();
 	for (slot_idx, slot) in atlas.data.slots.into_iter().enumerate() {
 		slot.save_with_format(format!("target/lightmaps/per-slot/slot_{slot_idx}.png"), image::ImageFormat::Png)
 			.unwrap();
@@ -38,7 +38,7 @@ fn main() {
 
 	fs::create_dir("target/lightmaps/per-style").unwrap();
 	eprintln!("Computing per style lightmap atlas");
-	let atlas = data.compute_lightmap_atlas(PerStyleLightmapPacker::new(lightmap_settings)).unwrap();
+	let atlas = data.compute_lightmap_atlas(PerStyleLightmapPackerRgb::new(lightmap_settings)).unwrap();
 	for (style, image) in atlas.data.inner() {
 		image
 			.save_with_format(format!("target/lightmaps/per-style/{}.png", style.0), image::ImageFormat::Png)


### PR DESCRIPTION
I'm currently working on [`vbsp`](https://github.com/eira-fransham/vbsp), and I'd like to reuse some of the infrastructure from `qbsp`. Eventually we might be able to bring these two crates even closer together, but the lightmap packer is by far the single most useful thing to pull in, and I'd rather avoid rewriting it. This involves removing a couple of unused fields and only pulling in the fields of `Face` that are necessary for lightmap calculations.